### PR TITLE
pyenv + xargs seems broken for some reason

### DIFF
--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -1676,8 +1676,9 @@ config("export_dynamic") {
 
 # thin_archive -----------------------------------------------------------------
 #
-# Enables thin archives on posix.  Regular archives directly include the object
-# files used to generate it.  Thin archives merely reference the object files.
+# Enables thin archives on posix, and on windows when the lld linker is used.
+# Regular archives directly include the object files used to generate it.
+# Thin archives merely reference the object files.
 # This makes building them faster since it requires less disk IO, but is
 # inappropriate if you wish to redistribute your static library.
 # This config is added to the global config, so thin archives should already be
@@ -1693,6 +1694,8 @@ config("thin_archive") {
   # archive names to 16 characters, which is not what we want).
   if ((is_posix && !is_nacl && !is_mac && !is_ios) || is_fuchsia) {
     arflags = [ "-T" ]
+  } else if (is_win && use_lld) {
+    arflags = [ "/llvmlibthin" ]
   }
 }
 

--- a/linux/sysroot_ld_path.sh
+++ b/linux/sysroot_ld_path.sh
@@ -94,6 +94,8 @@ elif [ -e "$LD_SO_CONF_D" ]; then
   if [ $? -eq 0 ]; then
     for entry in $LD_SO_CONF_D/*.conf; do
       process_ld_so_conf "$1" "$entry"
-    done | xargs echo
+        # pyenv is fooled by xargs echo; don't know why.
+        echo "$1" "$entry"
+    done
   fi
 fi

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -9,9 +9,17 @@ import("//build/config/win/visual_studio_version.gni")
 import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/goma.gni")
 import("//build/toolchain/toolchain.gni")
+import("//build/toolchain/cc_wrapper.gni")
 
 # Should only be running on Windows.
 assert(is_win)
+
+# If cc_wrapper if is set, add a space to it.
+if (cc_wrapper == "") {
+  cc_wrapper_prefix = ""
+} else {
+  cc_wrapper_prefix = "$cc_wrapper "
+}
 
 # Setup the Visual Studio state.
 #
@@ -362,7 +370,7 @@ if (win_build_host_cpu != "x64") {
 
   msvc_toolchain(win_build_host_cpu) {
     environment = "environment." + win_build_host_cpu
-    cl = "${goma_prefix}\"${build_cpu_toolchain_data.vc_bin_dir}/cl.exe\""
+    cl = "${goma_prefix}${cc_wrapper_prefix}\"${build_cpu_toolchain_data.vc_bin_dir}/cl.exe\""
     if (host_os != "win") {
       # For win cross build.
       sys_lib_flags = "${build_cpu_toolchain_data.libpath_flags}"
@@ -377,7 +385,7 @@ if (win_build_host_cpu != "x64") {
   msvc_toolchain("win_clang_" + win_build_host_cpu) {
     environment = "environment." + win_build_host_cpu
     prefix = rebase_path("$clang_base_path/bin", root_build_dir)
-    cl = "${goma_prefix}$prefix/${clang_cl}"
+    cl = "${goma_prefix}${cc_wrapper_prefix}$prefix/${clang_cl}"
     sys_include_flags = "${build_cpu_toolchain_data.include_flags_imsvc}"
     if (host_os != "win") {
       # For win cross build.
@@ -407,7 +415,7 @@ x64_toolchain_data = exec_script("setup_toolchain.py",
 template("win_x64_toolchains") {
   msvc_toolchain(target_name) {
     environment = "environment.x64"
-    cl = "${goma_prefix}\"${x64_toolchain_data.vc_bin_dir}/cl.exe\""
+    cl = "${goma_prefix}${cc_wrapper_prefix}\"${x64_toolchain_data.vc_bin_dir}/cl.exe\""
     if (host_os != "win") {
       # For win cross build
       sys_lib_flags = "${x64_toolchain_data.libpath_flags}"
@@ -426,7 +434,7 @@ template("win_x64_toolchains") {
   msvc_toolchain("win_clang_" + target_name) {
     environment = "environment.x64"
     prefix = rebase_path("$clang_base_path/bin", root_build_dir)
-    cl = "${goma_prefix}$prefix/${clang_cl}"
+    cl = "${goma_prefix}${cc_wrapper_prefix}$prefix/${clang_cl}"
     sys_include_flags = "${x64_toolchain_data.include_flags_imsvc}"
     if (host_os != "win") {
       # For win cross build
@@ -479,7 +487,7 @@ if (target_os == "winuwp") {
 
   msvc_toolchain("uwp_" + target_cpu) {
     environment = "environment.store_" + target_cpu
-    cl = "${goma_prefix}\"${store_cpu_toolchain_data.vc_bin_dir}/cl.exe\""
+    cl = "${goma_prefix}${cc_wrapper_prefix}\"${store_cpu_toolchain_data.vc_bin_dir}/cl.exe\""
     toolchain_args = {
       current_os = "winuwp"
       current_cpu = target_cpu

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -6,10 +6,10 @@ import("//build/config/clang/clang.gni")
 import("//build/config/compiler/compiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 import("//build/config/win/visual_studio_version.gni")
+import("//build/toolchain/cc_wrapper.gni")
 import("//build/toolchain/clang_static_analyzer.gni")
 import("//build/toolchain/goma.gni")
 import("//build/toolchain/toolchain.gni")
-import("//build/toolchain/cc_wrapper.gni")
 
 # Should only be running on Windows.
 assert(is_win)
@@ -174,13 +174,35 @@ template("msvc_toolchain") {
       # Label names may have spaces in them so the pdbname must be quoted. The
       # source and output don't need to be quoted because GN knows they're a
       # full file name and will quote automatically when necessary.
-      depsformat = "msvc"
       description = "CC {{output}}"
       outputs = [
         "$object_subdir/{{source_name_part}}.obj",
       ]
 
-      command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
+      if (!toolchain_uses_clang) {
+        depsflags = "/showIncludes"
+        depsformat = "msvc"
+      } else {
+        # Write header deps to a file instead of writing to stdout. This ensures
+        # compatibility with sccache and potentially other tools that add the
+        # `/E` (preprocess to stdout) flag, which our version of clang-cl
+        # doesn't properly support in conjunction with `/showIncludes`.
+        # See https://reviews.llvm.org/D46394
+        # and https://github.com/mozilla/sccache/issues/246
+
+        # We can't pass `-MMD -MF` (as it's done in gcc_toolchain.gni) to
+        # clang-cl, not even when prefixed with `-Xclang`. The underlying cc1
+        # binary does know how to generate depfiles but it requires somewhat
+        # different flags.
+        # See https://bugzilla.mozilla.org/show_bug.cgi?id=1340588
+        # and https://hg.mozilla.org/mozilla-central/rev/30dc6c484d42
+        depfile = "{{output}}.d"
+        depsflags = "-Xclang -dependency-file -Xclang \"$depfile\" " +
+                    "-Xclang -MT -Xclang {{source}} -Xclang -MP -Xclang -MG"
+        depsformat = "gcc"
+      }
+
+      command = "$env_wrapper$cl /nologo ${depsflags} ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
     }
 
     tool("cxx") {
@@ -190,13 +212,23 @@ template("msvc_toolchain") {
       pdbname = "{{target_out_dir}}/{{label_name}}_cc.pdb"
 
       # See comment in CC tool about quoting.
-      depsformat = "msvc"
       description = "CXX {{output}}"
       outputs = [
         "$object_subdir/{{source_name_part}}.obj",
       ]
 
-      command = "$env_wrapper$cl /nologo /showIncludes ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
+      if (!toolchain_uses_clang) {
+        depsflags = "/showIncludes"
+        depsformat = "msvc"
+      } else {
+        # See comments in CC tool about clang-cl depfile generation.
+        depfile = "{{output}}.d"
+        depsflags = "-Xclang -dependency-file -Xclang \"$depfile\" " +
+                    "-Xclang -MT -Xclang {{source}} -Xclang -MP -Xclang -MG"
+        depsformat = "gcc"
+      }
+
+      command = "$env_wrapper$cl /nologo ${depsflags} ${clflags} $sys_include_flags{{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} /c {{source}} /Fo{{output}} /Fd\"$pdbname\""
     }
 
     tool("rc") {

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -116,7 +116,7 @@ template("msvc_toolchain") {
 
       # lld-link includes a replacement for lib.exe that can produce thin
       # archives and understands bitcode (for lto builds).
-      lib = "$prefix/$lld_link /lib /llvmlibthin"
+      lib = "$prefix/$lld_link /lib"
       link = "$prefix/$lld_link"
       if (host_os != "win") {
         # See comment adding --rsp-quoting to $cl above for more information.


### PR DESCRIPTION
In the course of getting deno to build with pyenv, I had to modify this script to avoid a syntax error. I might have done it wrong, you might actually want to print stdout of process_ld_so_conf. But piping into xargs breaks pyenv.