### PR TITLE
Remove -no-opaque-pointers flag

### DIFF
--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -1564,16 +1564,6 @@ config("default_warnings") {
         cflags += [ "-Wno-unqualified-std-cast-call" ]
       }
 
-      if (!is_nacl && !(is_chromeos ||
-                        default_toolchain == "//build/toolchain/cros:target") &&
-          clang_major_version >= 15) {
-        # TODO(https://crbug.com/1316298): Re-enable once test failure is figured out
-        cflags += [
-          "-Xclang",
-          "-no-opaque-pointers",
-        ]
-      }
-
       if (is_fuchsia) {
         # TODO(https://bugs.chromium.org/p/fuchsia/issues/detail?id=77383)
         cflags += [ "-Wno-deprecated-copy" ]


### PR DESCRIPTION
According to the upstream bug report, the flag should no longer be
necessary and it causes a failure on platforms where it is not
supported.