### PR TITLE
fix: remove `enable_ios_bitcode` usage

### DIFF
--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -2558,7 +2558,7 @@ config("minimal_symbols") {
   }
 
   if (!is_nacl && is_clang && !is_tsan && !is_asan && !is_win &&
-      !is_ios && !line_tables_only) {
+      !line_tables_only) {
     # See comment for -gdwarf-aranges in config("symbols").
     cflags += [ "-gdwarf-aranges" ]
   }

--- a/config/compiler/BUILD.gn
+++ b/config/compiler/BUILD.gn
@@ -2558,7 +2558,7 @@ config("minimal_symbols") {
   }
 
   if (!is_nacl && is_clang && !is_tsan && !is_asan && !is_win &&
-      !(is_ios && enable_ios_bitcode) && !line_tables_only) {
+      !is_ios && !line_tables_only) {
     # See comment for -gdwarf-aranges in config("symbols").
     cflags += [ "-gdwarf-aranges" ]
   }


### PR DESCRIPTION
See https://github.com/denoland/chromium_build/commit/dcce175460a0b44424dc60849a9e72b709c72f7d
I think it was accidentally added in https://github.com/denoland/chromium_build/commit/8f821fc328257ca5529638001977d851d68d4051

iOS builds are blocked by this.