### PR TITLE
chore: cleanup format args

### DIFF
--- a/rust/chromium_prelude/import_attribute.rs
+++ b/rust/chromium_prelude/import_attribute.rs
@@ -100,7 +100,7 @@ impl Parse for ImportList {
                     Err(e) => {
                         return Err(Error::new(
                             str_span,
-                            format!("invalid GN path {}: {}", quote::quote! {#label}, e),
+                            format!("invalid GN path {}: {e}", quote::quote! {#label}),
                         ));
                     }
                 },

--- a/rust/tests/test_rust_shared_library/src/lib.rs
+++ b/rust/tests/test_rust_shared_library/src/lib.rs
@@ -28,7 +28,7 @@ pub fn say_hello() {
 pub fn alloc_aligned() {
     let layout = unsafe { Layout::from_size_align_unchecked(1024, 512) };
     let ptr = unsafe { alloc(layout) };
-    println!("Alloc aligned ptr: {:p}", ptr);
+    println!("Alloc aligned ptr: {ptr:p}");
     unsafe { dealloc(ptr, layout) };
 }
 

--- a/rust/tests/test_rust_static_library/src/lib.rs
+++ b/rust/tests/test_rust_static_library/src/lib.rs
@@ -30,7 +30,7 @@ pub fn say_hello() {
 pub fn alloc_aligned() {
     let layout = unsafe { Layout::from_size_align_unchecked(1024, 512) };
     let ptr = unsafe { alloc(layout) };
-    println!("Alloc aligned ptr: {:p}", ptr);
+    println!("Alloc aligned ptr: {ptr:p}");
     unsafe { dealloc(ptr, layout) };
 }
 


### PR DESCRIPTION
Manually clean up [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) clippy lint.  Some of these changes cause about 5% performance improvements because `format!("{}", &var)` does not need a reference and cannot be optimized by the compiler (but in thees cases the perf difference is less important)