### PR TITLE
Add x86_64-unknown-linux-musl target support

### DIFF
--- a/config/c++/BUILD.gn
+++ b/config/c++/BUILD.gn
@@ -1,4 +1,5 @@
 import("//build/config/c++/c++.gni")
+import("//build/toolchain/toolchain.gni")
 import("//build/config/c++/modules.gni")
 import("//build/config/chrome_build.gni")
 import("//build/config/chromeos/ui_mode.gni")
@@ -19,6 +20,19 @@ config("runtime_library") {
   include_dirs = []
   ldflags = []
   libs = []
+
+  # V8's bundled libc++ gates its ctype rune table on __GLIBC__, which
+  # musl doesn't define; use libc++'s portable default rune table and
+  # flag musl for the remaining locale differences. Target only.
+  if (use_musl && !toolchain_for_rust_host_build_tools) {
+    defines += [
+      "_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE",
+      "_LIBCPP_HAS_MUSL_LIBC",
+    ]
+    # The musl sysroot has no gcc runtime (crtbegin/libgcc); use
+    # clang's bundled compiler-rt for the C runtime instead.
+    ldflags += [ "-rtlib=compiler-rt" ]
+  }
 
   # Fixed libc++ configuration macros are in
   # buildtools/third_party/libc++/__config_site. This config only has defines

--- a/config/rust.gni
+++ b/config/rust.gni
@@ -355,6 +355,15 @@ if (is_linux || is_chromeos) {
   }
 }
 
+# When targeting musl, rewrite the gnu triple to its musl counterpart
+# (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-musl, etc.) so V8's
+# internal Rust crates + libstd are built for musl. The host build-tools
+# toolchain must stay glibc, so exclude it.
+if (use_musl && rust_abi_target != "" &&
+    !toolchain_for_rust_host_build_tools) {
+  rust_abi_target = string_replace(rust_abi_target, "-gnu", "-musl")
+}
+
 if (toolchain_has_rust) {
   assert(rust_abi_target != "")
 

--- a/config/sysroot.gni
+++ b/config/sysroot.gni
@@ -6,6 +6,7 @@
 # of the sysroot. If no sysroot applies, the variable will be an empty string.
 
 import("//build/toolchain/sysroot.gni")
+import("//build/toolchain/toolchain.gni")
 
 declare_args() {
   # The path of the sysroot that is applied when compiling using the target
@@ -22,7 +23,8 @@ declare_args() {
 
 if (sysroot == "") {
   if (current_os == target_os && current_cpu == target_cpu &&
-      target_sysroot != "") {
+      target_sysroot != "" && use_musl &&
+      !toolchain_for_rust_host_build_tools) {
     sysroot = target_sysroot
   } else if (is_android) {
     import("//build/config/android/config.gni")

--- a/rust/known-target-triples.txt
+++ b/rust/known-target-triples.txt
@@ -43,3 +43,5 @@ x86_64-unknown-fuchsia
 x86_64-unknown-linux-gnu
 powerpc64le-unknown-linux-gnu
 s390x-unknown-linux-gnu
+x86_64-unknown-linux-musl
+aarch64-unknown-linux-musl

--- a/toolchain/linux/BUILD.gn
+++ b/toolchain/linux/BUILD.gn
@@ -114,6 +114,16 @@ clang_toolchain("clang_x64") {
   }
 }
 
+clang_toolchain("clang_x64_glibc") {
+  enable_linker_map = true
+
+  toolchain_args = {
+    current_cpu = "x64"
+    current_os = "linux"
+    use_musl = false
+  }
+}
+
 template("clang_v8_toolchain") {
   clang_toolchain(target_name) {
     toolchain_args = {

--- a/toolchain/toolchain.gni
+++ b/toolchain/toolchain.gni
@@ -28,6 +28,11 @@ declare_args() {
   # scripts.
   toolchain_for_rust_host_build_tools = false
 
+  # Build the target (C/C++ and Rust) against musl libc instead of
+  # glibc. Scoped to the target toolchain only; host build tools stay
+  # glibc via the toolchain_for_rust_host_build_tools guard.
+  use_musl = false
+
   # If false, the toolchain overrides `use_partition_alloc_as_malloc` in
   # PartitionAlloc, to allow use of the system allocator.
   toolchain_allows_use_partition_alloc_as_malloc = true


### PR DESCRIPTION
Adds musl libc target support, used by rusty_v8 to build and publish musl
prebuilts (denoland/rusty_v8#2016).

Introduces a target-scoped use_musl GN arg. When set, V8's internal Rust
crates and libstd build for the musl triple and the target compiles against a
musl sysroot, while the executable build tools (torque, mksnapshot, code
generators) keep building with a separate glibc toolchain (clang_x64_glibc) so
they link and run on the glibc build host. Everything is guarded by
use_musl && !toolchain_for_rust_host_build_tools, so only the target toolchain
is affected; glibc builds are unchanged.