### PR TITLE
Scope musl to the target toolchain (enable arm64 musl)

### DIFF
--- a/config/c++/BUILD.gn
+++ b/config/c++/BUILD.gn
@@ -24,7 +24,7 @@ config("runtime_library") {
   # V8's bundled libc++ gates its ctype rune table on __GLIBC__, which
   # musl doesn't define; use libc++'s portable default rune table and
   # flag musl for the remaining locale differences. Target only.
-  if (use_musl && !toolchain_for_rust_host_build_tools) {
+  if (use_musl && current_toolchain == default_toolchain) {
     defines += [
       "_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE",
       "_LIBCPP_HAS_MUSL_LIBC",

--- a/config/rust.gni
+++ b/config/rust.gni
@@ -357,10 +357,11 @@ if (is_linux || is_chromeos) {
 
 # When targeting musl, rewrite the gnu triple to its musl counterpart
 # (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-musl, etc.) so V8's
-# internal Rust crates + libstd are built for musl. The host build-tools
-# toolchain must stay glibc, so exclude it.
+# internal Rust crates + libstd are built for musl. Only the default (target)
+# toolchain is musl; host and snapshot toolchains (which build executable build
+# tools that run on the glibc build host) stay glibc.
 if (use_musl && rust_abi_target != "" &&
-    !toolchain_for_rust_host_build_tools) {
+    current_toolchain == default_toolchain) {
   rust_abi_target = string_replace(rust_abi_target, "-gnu", "-musl")
 }
 

--- a/config/sysroot.gni
+++ b/config/sysroot.gni
@@ -24,7 +24,7 @@ declare_args() {
 if (sysroot == "") {
   if (current_os == target_os && current_cpu == target_cpu &&
       target_sysroot != "" && use_musl &&
-      !toolchain_for_rust_host_build_tools) {
+      current_toolchain == default_toolchain) {
     sysroot = target_sysroot
   } else if (is_android) {
     import("//build/config/android/config.gni")


### PR DESCRIPTION
Follow-up to the musl support (#205), needed for aarch64-unknown-linux-musl.

arm64 musl is a cross build (x64 host, arm64 target), and V8 builds mksnapshot
with an x64 host snapshot toolchain (clang_x64_v8_arm64). The previous guard
(!toolchain_for_rust_host_build_tools) let the global use_musl leak onto that
x64 snapshot toolchain, which would build it against a glibc sysroot but with
musl rust/libc++ config.

Tightening the guard to current_toolchain == default_toolchain scopes musl to
the target toolchain only, so host and snapshot toolchains stay glibc for any
target arch without per-arch variants. x86_64 musl is unaffected -- its host is
already the non-default clang_x64_glibc toolchain.